### PR TITLE
Fix image path resolution with imageBaseDir

### DIFF
--- a/pkg/domain/converter/converter.go
+++ b/pkg/domain/converter/converter.go
@@ -135,6 +135,8 @@ func convertImage(n *ast.Image, source []byte, mdFilePath string, imageBaseDir s
 	var baseDir string
 	if imageBaseDir != "" && strings.HasPrefix(dest, "/") {
 		// Absolute path with imageBaseDir: resolve relative to imageBaseDir
+		// Strip leading slash to treat as relative to imageBaseDir
+		dest = strings.TrimPrefix(dest, "/")
 		baseDir = filepath.Clean(imageBaseDir)
 		localPath = filepath.Join(imageBaseDir, dest)
 	} else {


### PR DESCRIPTION
## Summary
Fix image path resolution when using `--image-base-dir` with absolute paths in markdown.

## Problem
When an image path starts with `/` (e.g., `![](/image.png)`) and `--image-base-dir` is specified, `filepath.Join(baseDir, dest)` treats the second argument as an absolute path and ignores the first argument, resulting in incorrect path resolution.

## Solution
Strip the leading slash from image paths before joining with `imageBaseDir`, treating them as relative paths.

## Changes
- Add `strings.TrimPrefix(dest, "/")` in `convertImage` function before `filepath.Join`
- This ensures `![](/qa.png)` with `--image-base-dir /base` resolves to `/base/qa.png` instead of `/qa.png`

## Testing
- Verified the fix resolves the issue where images were not found in ubie-inc/tech-docs workflow
- Image paths are now correctly resolved relative to `imageBaseDir`