### PR TITLE
ci: namespace Go cache key by workflow

### DIFF
--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -34,9 +34,9 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-${{ github.workflow }}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-
+            ${{ runner.os }}-go-${{ github.workflow }}-
 
       - name: Run Gosec Security Scanner
         uses: securego/gosec@v2.24.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,9 +31,9 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-${{ github.workflow }}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-
+            ${{ runner.os }}-go-${{ github.workflow }}-
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,9 +29,9 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-${{ github.workflow }}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-
+            ${{ runner.os }}-go-${{ github.workflow }}-
 
       - name: Run tests
         run: go test ./...


### PR DESCRIPTION
## Summary

Add `${{ github.workflow }}` to the explicit `actions/cache@v4` key and `restore-keys` in `lint.yml`, `test.yml`, and `gosec.yml` so each workflow gets its own cache namespace.

## Why

Today all three workflows share the same cache key (`${{ runner.os }}-go-<hash>`) plus a loose `restore-keys` fallback of `${{ runner.os }}-go-`. That fallback will happily restore a cache built by any of the three workflows, and from any earlier commit whose `go.sum` differs. It is currently safe because no workflow uses `pull_request_target`, but if that trigger is ever introduced the same fallback would let one workflow poison another's cache. Namespacing by `github.workflow` removes the cross-workflow restore path while keeping the within-workflow cache benefit.

## Test plan
- [ ] Verify CI still passes (cache will be cold on the first run after merge, which is expected)